### PR TITLE
fix Watcom wmake make files

### DIFF
--- a/FIXME-BROKEN/td2192r/watcom_c.mak
+++ b/FIXME-BROKEN/td2192r/watcom_c.mak
@@ -5,7 +5,7 @@ CC       = wcc
 LINKER   = wcl
 CFLAGS   = -zq -ms -s -bt=com -oilrtfm -fr=nul -wx -0 -fo=.obj -dSTDC -q
 
-.C.OBJ:
+.c.obj:
 	$(CC) $(CFLAGS) $[@
 
 all: tdchoose.com

--- a/cxx/common.mak
+++ b/cxx/common.mak
@@ -10,21 +10,21 @@ NOW_BUILDING = CXX
 
 CFLAGS_THIS = -fr=nul -fo=$(SUBDIR)$(HPS).obj -i..
 
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.CPP.OBJ:
+.cpp.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CXX) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/dmopatch/incentiv/common.mak
+++ b/dmopatch/incentiv/common.mak
@@ -14,7 +14,7 @@ PATCH_EXE = $(SUBDIR)$(HPS)patch.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/dosbox/bins/prebios/common.mak
+++ b/dosbox/bins/prebios/common.mak
@@ -29,11 +29,11 @@ $(EMPTY_BIN): empty.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/dosbox/bins/preboot/common.mak
+++ b/dosbox/bins/preboot/common.mak
@@ -29,11 +29,11 @@ $(EMPTY_BIN): empty.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/dosdrv/hello/watcom_c.mak
+++ b/dosdrv/hello/watcom_c.mak
@@ -17,7 +17,7 @@ drva.asm:
 dos86s/drva.obj: drva.asm
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
-.C.OBJ:
+.c.obj:
 	$(CC) $(CFLAGS) $[@
 
 ../../hw/dos/dos86l/dos.lib:

--- a/dosdrv/hellof/watcom_c.mak
+++ b/dosdrv/hellof/watcom_c.mak
@@ -18,7 +18,7 @@ drva.asm:
 dos86s/drva.obj: drva.asm
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
-.C.OBJ:
+.c.obj:
 	$(CC) $(CFLAGS) $[@
 
 ../../hw/dos/dos86l/dos.lib:

--- a/ext/bzip2/common.mak
+++ b/ext/bzip2/common.mak
@@ -24,7 +24,7 @@ $(EXT_BZIP2_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/faad/common.mak
+++ b/ext/faad/common.mak
@@ -31,7 +31,7 @@ $(EXT_FAAD_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/flac/common.mak
+++ b/ext/flac/common.mak
@@ -7,7 +7,7 @@ OBJS = $(SUBDIR)$(HPS)bitmath.obj $(SUBDIR)$(HPS)bitreader.obj $(SUBDIR)$(HPS)bi
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/jpeg/common.mak
+++ b/ext/jpeg/common.mak
@@ -24,7 +24,7 @@ $(EXT_JPEG_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/lame/common.mak
+++ b/ext/lame/common.mak
@@ -81,7 +81,7 @@ $(EXT_LAME_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/libmad/common.mak
+++ b/ext/libmad/common.mak
@@ -17,7 +17,7 @@ $(EXT_LIBMAD_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/libogg/common.mak
+++ b/ext/libogg/common.mak
@@ -12,7 +12,7 @@ $(EXT_LIBOGG_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/speex/common.mak
+++ b/ext/speex/common.mak
@@ -26,7 +26,7 @@ $(EXT_SPEEX_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/vorbis/common.mak
+++ b/ext/vorbis/common.mak
@@ -23,7 +23,7 @@ $(EXT_VORBIS_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/vorbtool/common.mak
+++ b/ext/vorbtool/common.mak
@@ -17,7 +17,7 @@ OBJS = $(SUBDIR)$(HPS)audio.obj $(SUBDIR)$(HPS)easyflac.obj $(SUBDIR)$(HPS)encod
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/zlib/common.mak
+++ b/ext/zlib/common.mak
@@ -26,7 +26,7 @@ $(EXT_ZLIB_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/ext/zlibimin/common.mak
+++ b/ext/zlibimin/common.mak
@@ -12,7 +12,7 @@ $(EXT_ZLIBIMIN_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/fmt/minipng/common.mak
+++ b/fmt/minipng/common.mak
@@ -17,7 +17,7 @@ TESTOLD1_EXE = $(SUBDIR)$(HPS)testold1.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/fmt/omf/common.mak
+++ b/fmt/omf/common.mak
@@ -45,7 +45,7 @@ $(FMT_OMF_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/games/dgjamfall2020/codenamesunfish3d/devasset/woo-sorcerer-character/set1/vrltest/common.mak
+++ b/games/dgjamfall2020/codenamesunfish3d/devasset/woo-sorcerer-character/set1/vrltest/common.mak
@@ -8,7 +8,7 @@ TEST_EXE =     $(SUBDIR)$(HPS)test.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/games/dgjamfall2020/codenamesunfish3d/devasset/woo-sorcerer-character/set2/vrltest/common.mak
+++ b/games/dgjamfall2020/codenamesunfish3d/devasset/woo-sorcerer-character/set2/vrltest/common.mak
@@ -8,7 +8,7 @@ TEST_EXE =     $(SUBDIR)$(HPS)test.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/games/dgjamfall2020/codenamesunfish3d/game/common.mak
+++ b/games/dgjamfall2020/codenamesunfish3d/game/common.mak
@@ -14,7 +14,7 @@ COMMON_LIB =	 $(SUBDIR)$(HPS)common.lib
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/games/ifiction/first1/common.mak
+++ b/games/ifiction/first1/common.mak
@@ -22,11 +22,11 @@ IFICT_EXE =     ifictdos.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 
-.CPP.OBJ:
+.cpp.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CXX) @tmp.cmd
 

--- a/games/textdng1/common.mak
+++ b/games/textdng1/common.mak
@@ -14,7 +14,7 @@ GAME_EXE =    $(SUBDIR)$(HPS)game.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/8042/common.mak
+++ b/hw/8042/common.mak
@@ -12,7 +12,7 @@ $(HW_8042_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/8237/common.mak
+++ b/hw/8237/common.mak
@@ -12,7 +12,7 @@ $(HW_8237_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/hw/8250/common.mak
+++ b/hw/8250/common.mak
@@ -26,7 +26,7 @@ $(HW_8250PNP_LIB): $(OBJSPNP)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/8251/common.mak
+++ b/hw/8251/common.mak
@@ -12,7 +12,7 @@ $(HW_8251_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/8254/common.mak
+++ b/hw/8254/common.mak
@@ -32,7 +32,7 @@ $(HW_8254_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/8259/common.mak
+++ b/hw/8259/common.mak
@@ -20,7 +20,7 @@ $(HW_8259_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@ 
 	$(CC) @tmp.cmd
 

--- a/hw/86duino/common.mak
+++ b/hw/86duino/common.mak
@@ -13,7 +13,7 @@ $(HW_86DUINO_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/hw/acpi/common.mak
+++ b/hw/acpi/common.mak
@@ -12,7 +12,7 @@ $(HW_ACPI_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/adlib/common.mak
+++ b/hw/adlib/common.mak
@@ -15,7 +15,7 @@ $(HW_ADLIB_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/apm/common.mak
+++ b/hw/apm/common.mak
@@ -12,7 +12,7 @@ $(HW_APM_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/hw/biosdisk/common.mak
+++ b/hw/biosdisk/common.mak
@@ -19,11 +19,11 @@ $(HW_BIOSDISK_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-BIOSDISK
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/hw/cpu/common.mak
+++ b/hw/cpu/common.mak
@@ -82,14 +82,14 @@ $(HW_CPU_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS_CON) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/dos/common.mak
+++ b/hw/dos/common.mak
@@ -158,14 +158,14 @@ $(SUBDIR)$(HPS)dosntast.obj: dosntast.c
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/dosboxid/common.mak
+++ b/hw/dosboxid/common.mak
@@ -103,25 +103,25 @@ $(HW_DOSBOXID_LIB_DRVN): $(SUBDIR_DRVN) $(DRVN_OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C{$(SUBDIR)}.OBJ:
+.c{$(SUBDIR)}.obj:
 !ifdef TARGET_VXD
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS) $(CFLAGS_THIS_VXD) $[@
 !else
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS) $[@
 !endif
 
-.C{$(SUBDIR_CON)}.OBJ:
+.c{$(SUBDIR_CON)}.obj:
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 
 !ifdef HW_DOSBOXID_LIB_DRV
-.C{$(SUBDIR_DRV)}.OBJ:
+.c{$(SUBDIR_DRV)}.obj:
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS) $(CFLAGS_THIS_DRV) $[@
-.C{$(SUBDIR_DRV_ND)}.OBJ:
+.c{$(SUBDIR_DRV_ND)}.obj:
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS) $(CFLAGS_THIS_DRV_ND) $[@
 !endif
 
 !ifdef HW_DOSBOXID_LIB_DRVN
-.C{$(SUBDIR_DRVN)}.OBJ:
+.c{$(SUBDIR_DRVN)}.obj:
 	@$(CC) $(CFLAGS_THIS) $(CFLAGS) $(CFLAGS_THIS_DRVN) $[@
 !endif
 

--- a/hw/flatreal/common.mak
+++ b/hw/flatreal/common.mak
@@ -13,14 +13,14 @@ $(HW_FLATREAL_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-FLATREAL
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/floppy/common.mak
+++ b/hw/floppy/common.mak
@@ -13,7 +13,7 @@ $(HW_FLOPPY_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/ide/common.mak
+++ b/hw/ide/common.mak
@@ -15,7 +15,7 @@ $(HW_IDE_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/isapnp/common.mak
+++ b/hw/isapnp/common.mak
@@ -25,7 +25,7 @@ $(HW_ISAPNP_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/joystick/common.mak
+++ b/hw/joystick/common.mak
@@ -12,7 +12,7 @@ $(HW_JOYSTICK_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/hw/llmem/common.mak
+++ b/hw/llmem/common.mak
@@ -16,14 +16,14 @@ $(HW_LLMEM_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/mb/intel/piix3/common.mak
+++ b/hw/mb/intel/piix3/common.mak
@@ -12,7 +12,7 @@ $(HW_MB_INTEL_PIIX3_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/mpu401/common.mak
+++ b/hw/mpu401/common.mak
@@ -12,7 +12,7 @@ $(HW_MPU401_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/hw/necpc98/common.mak
+++ b/hw/necpc98/common.mak
@@ -23,7 +23,7 @@ $(HW_NECPC98_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/parport/common.mak
+++ b/hw/parport/common.mak
@@ -20,7 +20,7 @@ $(HW_PARPNP_LIB): $(OBJSPNP)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/pci/common.mak
+++ b/hw/pci/common.mak
@@ -17,14 +17,14 @@ $(HW_PCI_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/pcie/common.mak
+++ b/hw/pcie/common.mak
@@ -16,14 +16,14 @@ $(HW_PCIE_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/rtc/common.mak
+++ b/hw/rtc/common.mak
@@ -13,7 +13,7 @@ $(HW_RTC_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/smbios/common.mak
+++ b/hw/smbios/common.mak
@@ -12,7 +12,7 @@ $(HW_SMBIOS_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/sndsb/common.mak
+++ b/hw/sndsb/common.mak
@@ -81,7 +81,7 @@ $(HW_SNDSBPNP_LIB): $(OBJSPNP)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/ultrasnd/common.mak
+++ b/hw/ultrasnd/common.mak
@@ -14,7 +14,7 @@ $(HW_ULTRASND_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/usb/ohci/common.mak
+++ b/hw/usb/ohci/common.mak
@@ -16,14 +16,14 @@ $(HW_USB_OHCI_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/hw/utty/common.mak
+++ b/hw/utty/common.mak
@@ -11,7 +11,7 @@ $(HW_UTTY_LIB): $(SUBDIR)$(HPS)utty.obj $(SUBDIR)$(HPS)uttystr.obj $(SUBDIR)$(HP
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/vesa/common.mak
+++ b/hw/vesa/common.mak
@@ -18,7 +18,7 @@ $(HW_VESA_LIB): $(OBJS)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/vga/common.mak
+++ b/hw/vga/common.mak
@@ -82,7 +82,7 @@ $(HW_VGAGFX_LIB): $(SUBDIR)$(HPS)vgagfx.obj $(SUBDIR)$(HPS)gvg256.obj $(SUBDIR)$
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/hw/vga2/common.mak
+++ b/hw/vga2/common.mak
@@ -16,7 +16,7 @@ $(HW_VGA2_LIB): $(SUBDIR)$(HPS)vga2.obj $(SUBDIR)$(HPS)vgagdcc.obj $(SUBDIR)$(HP
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/media/dosamp/common.mak
+++ b/media/dosamp/common.mak
@@ -22,7 +22,7 @@ DOSAMP_EXE =    $(SUBDIR)$(HPS)dosamp.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/media/playmp3/common.mak
+++ b/media/playmp3/common.mak
@@ -22,7 +22,7 @@ M4ATOAAC_EXE = $(SUBDIR)$(HPS)m4atoaac.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 

--- a/misc/hexmem1/common.mak
+++ b/misc/hexmem1/common.mak
@@ -7,7 +7,7 @@ HEXMEM_EXE =  $(SUBDIR)$(HPS)hexmem.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/misc/zerofill/common.mak
+++ b/misc/zerofill/common.mak
@@ -7,7 +7,7 @@ ZEROFILL_EXE =  $(SUBDIR)$(HPS)zerofill.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/os2/hello/common.mak
+++ b/os2/hello/common.mak
@@ -10,7 +10,7 @@ HELLOPM_EXE =  $(SUBDIR)$(HPS)hellopm.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 

--- a/test-fw/video/pc/common.mak
+++ b/test-fw/video/pc/common.mak
@@ -11,7 +11,7 @@ VGA256T1_EXE = $(SUBDIR)$(HPS)vga256t1.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/tiny/beep1/common.mak
+++ b/tiny/beep1/common.mak
@@ -29,11 +29,11 @@ $(BEEP1_COM): beep1.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/beep2/common.mak
+++ b/tiny/beep2/common.mak
@@ -29,11 +29,11 @@ $(BEEP2_COM): beep2.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/bootrep/common.mak
+++ b/tiny/bootrep/common.mak
@@ -29,11 +29,11 @@ $(BOOTREP_COM): bootrep.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/cat/common.mak
+++ b/tiny/cat/common.mak
@@ -29,11 +29,11 @@ $(CAT_COM): cat.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/covoxwav/common.mak
+++ b/tiny/covoxwav/common.mak
@@ -29,11 +29,11 @@ $(COVOXWAV_COM): covoxwav.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/echo/common.mak
+++ b/tiny/echo/common.mak
@@ -29,11 +29,11 @@ $(ECHO_COM): echo.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/hello/common.mak
+++ b/tiny/hello/common.mak
@@ -29,11 +29,11 @@ $(HELLO_COM): hello.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/hexdump/common.mak
+++ b/tiny/hexdump/common.mak
@@ -29,11 +29,11 @@ $(HEXDUMP_COM): hexdump.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/more/common.mak
+++ b/tiny/more/common.mak
@@ -29,11 +29,11 @@ $(MORE_COM): more.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tiny/pcspkwav/common.mak
+++ b/tiny/pcspkwav/common.mak
@@ -29,11 +29,11 @@ $(PCSPKWAV_COM): pcspkwav.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw16/hello/common.mak
+++ b/tinyw16/hello/common.mak
@@ -41,11 +41,11 @@ $(HELLO_EXE): $(SUBDIR)$(HPS)hello.obj ..$(HPS)stub$(HPS)dos86s$(HPS)stub.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw16/hellowin/common.mak
+++ b/tinyw16/hellowin/common.mak
@@ -41,11 +41,11 @@ $(HELLO_EXE): $(SUBDIR)$(HPS)hello.obj ..$(HPS)stub$(HPS)dos86s$(HPS)stub.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw16/nothing/common.mak
+++ b/tinyw16/nothing/common.mak
@@ -39,11 +39,11 @@ $(HELLO_EXE): $(SUBDIR)$(HPS)hello.obj ..$(HPS)stub$(HPS)dos86s$(HPS)stub.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw16/stub/common.mak
+++ b/tinyw16/stub/common.mak
@@ -34,11 +34,11 @@ $(SUBDIR)$(HPS)stub.obj: stub.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw32/hello/common.mak
+++ b/tinyw32/hello/common.mak
@@ -37,11 +37,11 @@ $(HELLO_EXE): $(SUBDIR)$(HPS)hello.obj ..$(HPS)stub$(HPS)dos86s$(HPS)stub.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f win32 $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw32/nothing/common.mak
+++ b/tinyw32/nothing/common.mak
@@ -37,11 +37,11 @@ $(HELLO_EXE): $(SUBDIR)$(HPS)hello.obj ..$(HPS)stub$(HPS)dos86s$(HPS)stub.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f win32 $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tinyw32/stub/common.mak
+++ b/tinyw32/stub/common.mak
@@ -34,11 +34,11 @@ $(SUBDIR)$(HPS)stub.obj: stub.asm
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe .symbolic

--- a/tool/dsxmenu/common.mak
+++ b/tool/dsxmenu/common.mak
@@ -14,7 +14,7 @@ DSXMENU_EXE = $(SUBDIR)$(HPS)dsxmenu.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/tool/expr1/common.mak
+++ b/tool/expr1/common.mak
@@ -14,7 +14,7 @@ EXPR1_EXE = $(SUBDIR)$(HPS)expr1.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/tool/linker/common.mak
+++ b/tool/linker/common.mak
@@ -15,7 +15,7 @@ LNKDOS16_EXE = $(SUBDIR)$(HPS)lnkdos16.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/tool/linker/drv1/common.mak
+++ b/tool/linker/drv1/common.mak
@@ -27,11 +27,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linker/drv2/common.mak
+++ b/tool/linker/drv2/common.mak
@@ -27,11 +27,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linker/drv3/common.mak
+++ b/tool/linker/drv3/common.mak
@@ -41,11 +41,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linker/ex1/common.mak
+++ b/tool/linker/ex1/common.mak
@@ -42,14 +42,14 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/tool/linker/ex2/common.mak
+++ b/tool/linker/ex2/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex3/common.mak
+++ b/tool/linker/ex3/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex4/common.mak
+++ b/tool/linker/ex4/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex5/common.mak
+++ b/tool/linker/ex5/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex6/common.mak
+++ b/tool/linker/ex6/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex7/common.mak
+++ b/tool/linker/ex7/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex8/common.mak
+++ b/tool/linker/ex8/common.mak
@@ -30,11 +30,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/ex9/common.mak
+++ b/tool/linker/ex9/common.mak
@@ -33,11 +33,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/hello1/common.mak
+++ b/tool/linker/hello1/common.mak
@@ -29,11 +29,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linker/hello2/common.mak
+++ b/tool/linker/hello2/common.mak
@@ -29,11 +29,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: $(OMFSEGDG) lib exe

--- a/tool/linkplus/common.mak
+++ b/tool/linkplus/common.mak
@@ -11,11 +11,11 @@ NOW_BUILDING = TOOL_LINKER
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.CPP.OBJ:
+.cpp.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) -xs $[@
 	@$(CXX) @tmp.cmd
 

--- a/tool/linkplus/drv1/common.mak
+++ b/tool/linkplus/drv1/common.mak
@@ -31,11 +31,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linkplus/drv2/common.mak
+++ b/tool/linkplus/drv2/common.mak
@@ -33,11 +33,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linkplus/drv3/common.mak
+++ b/tool/linkplus/drv3/common.mak
@@ -35,11 +35,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $(CFLAGS_END) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 dos86t/drvci.obj: drvci.c

--- a/tool/linkplus/ex1/common.mak
+++ b/tool/linkplus/ex1/common.mak
@@ -42,11 +42,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe

--- a/tool/linkplus/ex2/common.mak
+++ b/tool/linkplus/ex2/common.mak
@@ -34,11 +34,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe

--- a/tool/linkplus/ex3/common.mak
+++ b/tool/linkplus/ex3/common.mak
@@ -34,11 +34,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe

--- a/tool/linkplus/ex4/common.mak
+++ b/tool/linkplus/ex4/common.mak
@@ -34,11 +34,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe

--- a/tool/linkplus/ex5/common.mak
+++ b/tool/linkplus/ex5/common.mak
@@ -34,11 +34,11 @@ $(DOSLIBLINKER):
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 all: lib exe

--- a/tool/necrc/common.mak
+++ b/tool/necrc/common.mak
@@ -14,7 +14,7 @@ NECRC_EXE = $(SUBDIR)$(HPS)necrc.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/tool/rec98/touhou/common.mak
+++ b/tool/rec98/touhou/common.mak
@@ -12,7 +12,7 @@ BMP2ARR_EXE =    $(SUBDIR)$(HPS)bmp2arr.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/tool/remctl/serial/common.mak
+++ b/tool/remctl/serial/common.mak
@@ -14,7 +14,7 @@ REMSRV_EXE = $(SUBDIR)$(HPS)remsrv.$(EXEEXT)
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	@$(CC) @tmp.cmd
 

--- a/windows/bethesda/common.mak
+++ b/windows/bethesda/common.mak
@@ -9,7 +9,7 @@ HELLO_EXE =  $(SUBDIR)$(HPS)hello.exe
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/windows/dispdib/common.mak
+++ b/windows/dispdib/common.mak
@@ -10,7 +10,7 @@ HELLO_RES =  $(SUBDIR)$(HPS)hello.res
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/windows/exmenus/common.mak
+++ b/windows/exmenus/common.mak
@@ -19,7 +19,7 @@ HELLO4_RES =  $(SUBDIR)$(HPS)hello4.res
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/windows/hello/common.mak
+++ b/windows/hello/common.mak
@@ -25,7 +25,7 @@ HELLDLD1_LIB =  $(SUBDIR)$(HPS)HELLDLD1.LIB
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/windows/hexmem/common.mak
+++ b/windows/hexmem/common.mak
@@ -10,7 +10,7 @@ HEXMEM_RES =  $(SUBDIR)$(HPS)hexmem.res
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE

--- a/windows/ntvdm/common.mak
+++ b/windows/ntvdm/common.mak
@@ -22,7 +22,7 @@ $(WINDOWS_NTVDMLIB_LIB): $(SUBDIR)$(HPS)ntvdmlib.obj $(SUBDIR)$(HPS)nterrstr.obj
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
@@ -33,7 +33,7 @@ $(SUBDIR)$(HPS)vddc1d.obj: vddc1d.c
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/windows/w9xvmm/common.mak
+++ b/windows/w9xvmm/common.mak
@@ -11,14 +11,14 @@ $(WINDOWS_W9XVMM_LIB): $(SUBDIR)$(HPS)vxd_enum.obj
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_CON) $[@
 	$(CC) @tmp.cmd
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@
 !endif
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 !ifdef TINYMODE
 	$(OMFSEGDG) -i $@ -o $@

--- a/windows/win16eb/common.mak
+++ b/windows/win16eb/common.mak
@@ -10,7 +10,7 @@ HELLO_RES =  $(SUBDIR)$(HPS)hello.res
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS) $[@
 	$(CC) @tmp.cmd
 

--- a/windrv/dosboxpi/win3x/common.mak
+++ b/windrv/dosboxpi/win3x/common.mak
@@ -16,11 +16,11 @@ DBOXMPI_DRV = $(SUBDIR)$(HPS)dboxmpi.drv
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_DLL) $(DISCARDABLE_CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 $(SUBDIR)$(HPS)inthndlr.obj: inthndlr.c

--- a/windrv/dosboxpi/win3x98/common.mak
+++ b/windrv/dosboxpi/win3x98/common.mak
@@ -16,11 +16,11 @@ DBOXMPI_DRV = $(SUBDIR)$(HPS)dboxmpi.drv
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_DLL) $(DISCARDABLE_CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 $(SUBDIR)$(HPS)inthndlr.obj: inthndlr.c

--- a/windrv/dosboxpi/win9x/common.mak
+++ b/windrv/dosboxpi/win9x/common.mak
@@ -23,11 +23,11 @@ DBOXMPI_DRV = $(SUBDIR)$(HPS)dboxmpi.drv
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_DLL) $(DISCARDABLE_CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 $(SUBDIR)$(HPS)inthndlr.obj: inthndlr.c

--- a/windrv/ps2mouse/win3x/common.mak
+++ b/windrv/ps2mouse/win3x/common.mak
@@ -16,11 +16,11 @@ PS2MOUSE_DRV = $(SUBDIR)$(HPS)ps2mouse.drv
 
 # NTS we have to construct the command line into tmp.cmd because for MS-DOS
 # systems all arguments would exceed the pitiful 128 char command line limit
-.C.OBJ:
+.c.obj:
 	%write tmp.cmd $(CFLAGS_THIS) $(CFLAGS_DLL) $(DISCARDABLE_CFLAGS) $[@
 	@$(CC) @tmp.cmd
 
-.ASM.OBJ:
+.asm.obj:
 	nasm -o $@ -f obj $(NASMFLAGS) $[@
 
 $(SUBDIR)$(HPS)inthndlr.obj: inthndlr.c


### PR DESCRIPTION
OW 2.0 properly use case-sensitive rules on *NIX hosts that make files need to use proper extensions in rules all previous Open Watcom version ignore case in rules, that this change is backward compatible