### PR TITLE
fix header issue on lnkdos16.cpp

### DIFF
--- a/tool/linkplus/lnkdos16.cpp
+++ b/tool/linkplus/lnkdos16.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdexcept>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
This had to be done on Ubuntu 22.04 as range_error was not being detected in the global scope. Not sure if other distros are affected by this. They likely are due to differing g++ versions